### PR TITLE
Feature: Support for multiple entry points

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ JS Config files are also supported, useful for loading environment variables and
 
 ### Fields
 
-- `srcFile`: path of the entry source file. Defaults to `src/index.ts`.
+- `entryPoints`: path of the entry source files. Defaults to `["src/index.ts"]`.
 - `target`: ECMAScript version target. Defaults to `esnext`.
 - `tsconfig`: path of Typescript config file. Defaults to `tsconfig.json`.
 - `jsx`: How JSX expressions should be interpreted. Defaults to `react`. Use `preserve` to preserve JSX syntax.
@@ -101,7 +101,7 @@ For types, the output file is inferred from the `"types"` field.
 
 ### `package.json`
 
-The following entrypoints must now be provided.  `./esm` and  `./cjs` entrypoints are optional.
+The following entrypoints must now be provided.  `./esm` and  `./cjs` entry points are optional.
 
 ```json
 {

--- a/packages/pridepack/README.md
+++ b/packages/pridepack/README.md
@@ -79,7 +79,7 @@ JS Config files are also supported, useful for loading environment variables and
 
 ### Fields
 
-- `srcFile`: path of the entry source file. Defaults to `src/index.ts`.
+- `entryPoints`: path of the entry source files. Defaults to `["src/index.ts"]`.
 - `target`: ECMAScript version target. Defaults to `esnext`.
 - `tsconfig`: path of Typescript config file. Defaults to `tsconfig.json`.
 - `jsx`: How JSX expressions should be interpreted. Defaults to `react`. Use `preserve` to preserve JSX syntax.
@@ -101,7 +101,7 @@ For types, the output file is inferred from the `"types"` field.
 
 ### `package.json`
 
-The following entrypoints must now be provided.  `./esm` and  `./cjs` entrypoints are optional.
+The following entrypoints must now be provided.  `./esm` and  `./cjs` entry points are optional.
 
 ```json
 {

--- a/packages/pridepack/src/core/build-cjs-development.ts
+++ b/packages/pridepack/src/core/build-cjs-development.ts
@@ -34,7 +34,12 @@ export default async function buildCJSDevelopment(incremental: boolean): Promise
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
   // get output directory
-  const outdir = path.resolve(await getCJSTargetDirectory(true));
+  const outdir = path.resolve(
+    path.join(
+      process.cwd(),
+      await getCJSTargetDirectory(true),
+    ),
+  );
 
   // run esbuild
   return build({

--- a/packages/pridepack/src/core/build-cjs-development.ts
+++ b/packages/pridepack/src/core/build-cjs-development.ts
@@ -46,13 +46,11 @@ export default async function buildCJSDevelopment(incremental: boolean): Promise
   if (config.jsx === 'preserve' && extension !== '.jsx') {
     extension = 'jsx';
   }
-  const outfile = path.join(parsed.dir, `${parsed.name}${extension}`);
+
   // run esbuild
   return build({
-    entryPoints: [
-      configCWD.srcFile,
-    ],
-    outfile,
+    entryPoints: configCWD.entryPoints,
+    outdir: parsed.dir,
     bundle: true,
     minify: false,
     platform: 'node',

--- a/packages/pridepack/src/core/build-cjs-development.ts
+++ b/packages/pridepack/src/core/build-cjs-development.ts
@@ -20,37 +20,26 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- */
+*/
 import path from 'path';
 import { build, BuildResult } from 'esbuild';
 import { DEVELOPMENT_ENV } from './read-env-defs';
 import readConfig from './read-config';
 import readConfigWithCWD from './read-config-with-cwd';
 import readExternals from './read-externals';
-import { resolveCJSEntry } from './build-cjs';
+import { getCJSTargetDirectory } from './build-cjs';
 
 export default async function buildCJSDevelopment(incremental: boolean): Promise<BuildResult> {
   const config = await readConfig();
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
-  // get outfile
-  const parsed = path.parse(
-    path.resolve(
-      path.join(
-        process.cwd(),
-        await resolveCJSEntry(true),
-      ),
-    ),
-  );
-  let extension = parsed.ext;
-  if (config.jsx === 'preserve' && extension !== '.jsx') {
-    extension = 'jsx';
-  }
+  // get output directory
+  const outdir = path.resolve(await getCJSTargetDirectory(true));
 
   // run esbuild
   return build({
     entryPoints: configCWD.entryPoints,
-    outdir: parsed.dir,
+    outdir,
     bundle: true,
     minify: false,
     platform: 'node',

--- a/packages/pridepack/src/core/build-cjs-production.ts
+++ b/packages/pridepack/src/core/build-cjs-production.ts
@@ -46,13 +46,11 @@ export default async function buildCJSProduction(incremental: boolean): Promise<
   if (config.jsx === 'preserve' && extension !== '.jsx') {
     extension = 'jsx';
   }
-  const outfile = path.join(parsed.dir, `${parsed.name}${extension}`);
+
   // run esbuild
   return build({
-    entryPoints: [
-      configCWD.srcFile,
-    ],
-    outfile,
+    entryPoints: configCWD.entryPoints,
+    outdir: parsed.dir,
     bundle: true,
     minify: true,
     platform: 'node',

--- a/packages/pridepack/src/core/build-cjs-production.ts
+++ b/packages/pridepack/src/core/build-cjs-production.ts
@@ -20,37 +20,26 @@
  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
- */
+*/
 import path from 'path';
 import { build, BuildResult } from 'esbuild';
 import { PRODUCTION_ENV } from './read-env-defs';
 import readConfigWithCWD from './read-config-with-cwd';
 import readExternals from './read-externals';
 import readConfig from './read-config';
-import { resolveCJSEntry } from './build-cjs';
+import { getCJSTargetDirectory } from './build-cjs';
 
 export default async function buildCJSProduction(incremental: boolean): Promise<BuildResult> {
   const config = await readConfig();
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
-  // get outfile
-  const parsed = path.parse(
-    path.resolve(
-      path.join(
-        process.cwd(),
-        await resolveCJSEntry(false),
-      ),
-    ),
-  );
-  let extension = parsed.ext;
-  if (config.jsx === 'preserve' && extension !== '.jsx') {
-    extension = 'jsx';
-  }
+  // get output director
+  const outdir = path.resolve(await getCJSTargetDirectory(false));
 
   // run esbuild
   return build({
     entryPoints: configCWD.entryPoints,
-    outdir: parsed.dir,
+    outdir,
     bundle: true,
     minify: true,
     platform: 'node',

--- a/packages/pridepack/src/core/build-cjs-production.ts
+++ b/packages/pridepack/src/core/build-cjs-production.ts
@@ -34,7 +34,12 @@ export default async function buildCJSProduction(incremental: boolean): Promise<
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
   // get output director
-  const outdir = path.resolve(await getCJSTargetDirectory(false));
+  const outdir = path.resolve(
+    path.join(
+      process.cwd(),
+      await getCJSTargetDirectory(false),
+    ),
+  );
 
   // run esbuild
   return build({

--- a/packages/pridepack/src/core/build-esm-development.ts
+++ b/packages/pridepack/src/core/build-esm-development.ts
@@ -46,13 +46,11 @@ export default async function buildESMDevelopment(incremental: boolean): Promise
   if (config.jsx === 'preserve' && extension !== '.jsx') {
     extension = 'jsx';
   }
-  const outfile = path.join(parsed.dir, `${parsed.name}${extension}`);
+
   // run esbuild
   return build({
-    entryPoints: [
-      configCWD.srcFile,
-    ],
-    outfile,
+    entryPoints: configCWD.entryPoints,
+    outdir: parsed.dir,
     bundle: true,
     minify: false,
     platform: 'node',

--- a/packages/pridepack/src/core/build-esm-development.ts
+++ b/packages/pridepack/src/core/build-esm-development.ts
@@ -27,30 +27,19 @@ import { DEVELOPMENT_ENV } from './read-env-defs';
 import readConfig from './read-config';
 import readConfigWithCWD from './read-config-with-cwd';
 import readExternals from './read-externals';
-import { resolveESMEntry } from './build-esm';
+import { getESMTargetDirectory } from './build-esm';
 
 export default async function buildESMDevelopment(incremental: boolean): Promise<BuildResult> {
   const config = await readConfig();
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
-  // get outfile
-  const parsed = path.parse(
-    path.resolve(
-      path.join(
-        process.cwd(),
-        await resolveESMEntry(true),
-      ),
-    ),
-  );
-  let extension = parsed.ext;
-  if (config.jsx === 'preserve' && extension !== '.jsx') {
-    extension = 'jsx';
-  }
+  // get output directory
+  const outdir = path.resolve(await getESMTargetDirectory(true));
 
   // run esbuild
   return build({
     entryPoints: configCWD.entryPoints,
-    outdir: parsed.dir,
+    outdir,
     bundle: true,
     minify: false,
     platform: 'node',

--- a/packages/pridepack/src/core/build-esm-development.ts
+++ b/packages/pridepack/src/core/build-esm-development.ts
@@ -34,7 +34,12 @@ export default async function buildESMDevelopment(incremental: boolean): Promise
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
   // get output directory
-  const outdir = path.resolve(await getESMTargetDirectory(true));
+  const outdir = path.resolve(
+    path.join(
+      process.cwd(),
+      await getESMTargetDirectory(true),
+    ),
+  );
 
   // run esbuild
   return build({

--- a/packages/pridepack/src/core/build-esm-production.ts
+++ b/packages/pridepack/src/core/build-esm-production.ts
@@ -27,30 +27,19 @@ import { PRODUCTION_ENV } from './read-env-defs';
 import readConfigWithCWD from './read-config-with-cwd';
 import readExternals from './read-externals';
 import readConfig from './read-config';
-import { resolveESMEntry } from './build-esm';
+import { getESMTargetDirectory } from './build-esm';
 
 export default async function buildESMProduction(incremental: boolean): Promise<BuildResult> {
   const config = await readConfig();
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
-  // get outfile
-  const parsed = path.parse(
-    path.resolve(
-      path.join(
-        process.cwd(),
-        await resolveESMEntry(false),
-      ),
-    ),
-  );
-  let extension = parsed.ext;
-  if (config.jsx === 'preserve' && extension !== '.jsx') {
-    extension = '.jsx';
-  }
+  // get output director
+  const outdir = path.resolve(await getESMTargetDirectory(false));
 
   // run esbuild
   return build({
     entryPoints: configCWD.entryPoints,
-    outdir: parsed.dir,
+    outdir,
     bundle: true,
     minify: true,
     platform: 'node',

--- a/packages/pridepack/src/core/build-esm-production.ts
+++ b/packages/pridepack/src/core/build-esm-production.ts
@@ -46,13 +46,11 @@ export default async function buildESMProduction(incremental: boolean): Promise<
   if (config.jsx === 'preserve' && extension !== '.jsx') {
     extension = '.jsx';
   }
-  const outfile = path.join(parsed.dir, `${parsed.name}${extension}`);
+
   // run esbuild
   return build({
-    entryPoints: [
-      configCWD.srcFile,
-    ],
-    outfile,
+    entryPoints: configCWD.entryPoints,
+    outdir: parsed.dir,
     bundle: true,
     minify: true,
     platform: 'node',

--- a/packages/pridepack/src/core/build-esm-production.ts
+++ b/packages/pridepack/src/core/build-esm-production.ts
@@ -34,7 +34,12 @@ export default async function buildESMProduction(incremental: boolean): Promise<
   const configCWD = await readConfigWithCWD();
   const externals = await readExternals();
   // get output director
-  const outdir = path.resolve(await getESMTargetDirectory(false));
+  const outdir = path.resolve(
+    path.join(
+      process.cwd(),
+      await getESMTargetDirectory(false),
+    ),
+  );
 
   // run esbuild
   return build({

--- a/packages/pridepack/src/core/compile-types.ts
+++ b/packages/pridepack/src/core/compile-types.ts
@@ -70,7 +70,7 @@ export default async function compileTypes(noEmit = true): Promise<ts.Diagnostic
   // Prepare and emit the d.ts files
   const configCWD = await readConfigWithCWD();
   const program = ts.createProgram(
-    [configCWD.srcFile],
+    configCWD.entryPoints,
     baseConfig,
     host,
   );

--- a/packages/pridepack/src/core/default-config.ts
+++ b/packages/pridepack/src/core/default-config.ts
@@ -24,7 +24,7 @@
 import { Plugin } from 'esbuild';
 
 export interface PridepackBaseConfig {
-  srcFile: string;
+  entryPoints: string[];
   tsconfig: string;
 }
 
@@ -45,7 +45,7 @@ export interface PridepackConfig extends PridepackBaseConfig {
 }
 
 const DEFAULT_CONFIG: PridepackConfig = {
-  srcFile: 'src/index.ts',
+  entryPoints: ['src/index.ts'],
   target: 'es2017',
   tsconfig: 'tsconfig.json',
 };

--- a/packages/pridepack/src/core/read-config-with-cwd.ts
+++ b/packages/pridepack/src/core/read-config-with-cwd.ts
@@ -36,7 +36,7 @@ export default async function readConfigWithCWD(): Promise<PridepackBaseConfig> 
   const config = await readConfig();
 
   CONFIG_WITH_CWD = {
-    srcFile: path.resolve(path.join(cwd, config.srcFile)),
+    entryPoints: config.entryPoints.map((entryPoint) => path.resolve(path.join(cwd, entryPoint))),
     tsconfig: path.resolve(path.join(cwd, config.tsconfig)),
   };
 

--- a/packages/pridepack/src/core/read-config.ts
+++ b/packages/pridepack/src/core/read-config.ts
@@ -64,7 +64,7 @@ export default async function readConfig(): Promise<PridepackConfig> {
 
       CONFIG = {
         ...customConfig,
-        srcFile: customConfig.srcFile || DEFAULT_CONFIG.srcFile,
+        entryPoints: customConfig.entryPoints || DEFAULT_CONFIG.entryPoints,
         tsconfig: customConfig.tsconfig || DEFAULT_CONFIG.tsconfig,
         target: customConfig.target || DEFAULT_CONFIG.target,
       };
@@ -81,7 +81,7 @@ export default async function readConfig(): Promise<PridepackConfig> {
 
       CONFIG = {
         ...customConfig,
-        srcFile: customConfig.srcFile || DEFAULT_CONFIG.srcFile,
+        entryPoints: customConfig.entryPoints || DEFAULT_CONFIG.entryPoints,
         tsconfig: customConfig.tsconfig || DEFAULT_CONFIG.tsconfig,
         target: customConfig.target || DEFAULT_CONFIG.target,
       };


### PR DESCRIPTION
This adds support for multiple entry points. Right now, we can only have and configure one entry point, which by default is `src/index`.

The rationale for this is to allow packages to also include modules that export with defaults that can be imported as is.

e.g.
```
import SomeComponent from '@org/components/SomeComponent`
```

