### PR TITLE
Include stderr in logs

### DIFF
--- a/packages/pridepack/src/program/run-start-command.ts
+++ b/packages/pridepack/src/program/run-start-command.ts
@@ -39,6 +39,7 @@ export default async function runStartCommand(isDev: boolean): Promise<void> {
         `${entrypoint}${ext}`,
         args,
       );
+      instance.stderr?.pipe(process.stderr);
       instance.stdout?.pipe(process.stdout);
       return instance;
     }


### PR DESCRIPTION
Only `stdout` outputs are included previously on commands like `dev`. Include the `stderr` output for easier debugging of start commands.